### PR TITLE
Add dbd keywords used by epics base dbds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - add record types: int64in, int64out, printf, lsi, lso
 - add fields: OCAL, OEVT, OOPT, MALM, DOPT, INDX, ALG, BALG, NSAM, SELM, SELN, SELL, SIZV, ODLY, FMT, INP0-INP9
 - improved highlighting of escaped quotation marks
+- add DBD keyswords: asl, initial, promptgroup, prompt, special, pp, interest, base, size, extra, menu, drop
+- add DBD enums for keywords: pp, asl, base, and special
+- add DBD types (e.g. DBF_DOUBLE)
 
 ## 0.0.10 - 2020-0-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - add DBD keyswords: asl, initial, promptgroup, prompt, special, pp, interest, base, size, extra, menu, drop
 - add DBD enums for keywords: pp, asl, base, and special
 - add DBD types (e.g. DBF_DOUBLE)
+- improved highlighting of escaped quotation marks in DBD
 
 ## 0.0.10 - 2020-0-07
 

--- a/syntaxes/dbd.tmLanguage.json
+++ b/syntaxes/dbd.tmLanguage.json
@@ -22,6 +22,14 @@
 				{
 					"name": "keyword.control.epics",
 					"match": "\\b(path|addpath|include|menu|choice|recordtype|field|device|driver|registrar|function|variable|breaktable|record|grecord|info|alias)\\b"
+				},
+				{
+					"name": "keyword.control.field.epics",
+					"match": "\\b(prompt|prompt[gG]roup|asl|interest|size|extra|special|menu)\\b"
+				},
+				{
+					"name": "constant.language.dbf.epics",
+					"match": "\\b(DBF_STRING|DBF_INT|DBF_FLOAT|DBF_ENUM|DBF_CHAR|DBF_LONG|DBF_DOUBLE|DBF_MENU)\\b"
 				}
 			]
 		},
@@ -29,7 +37,7 @@
 			"name": "string.quoted.double.epics",
 			"begin": "\"",
 			"end": "\"",
-			"patterns": [ 
+			"patterns": [
 				{
 					"name": "constant.character.escape.epics",
 					"match": "\\\\.",

--- a/syntaxes/dbd.tmLanguage.json
+++ b/syntaxes/dbd.tmLanguage.json
@@ -21,15 +21,37 @@
 			"patterns": [
 				{
 					"name": "keyword.control.epics",
-					"match": "\\b(path|addpath|include|menu|choice|recordtype|field|device|driver|registrar|function|variable|breaktable|record|grecord|info|alias)\\b"
+					"match": "\\b(path|addpath|include|menu|choice|recordtype|field|device|driver|registrar|function|variable|breaktable|record|grecord|info|alias|link)\\b"
 				},
 				{
 					"name": "keyword.control.field.epics",
-					"match": "\\b(prompt|prompt[gG]roup|asl|interest|size|extra|special|menu|pp)\\b"
+					"match": "\\b(asl|initial|promptgroup|prompt|special|pp|interest|base|size|extra|menu|prop)\\b",
+					"comment": "Source: dbRecordtypeFieldItem(), ioc/dbStatic/dbLexRoutines.c"
 				},
 				{
 					"name": "constant.language.dbf.epics",
-					"match": "\\b(DBF_STRING|DBF_INT|DBF_FLOAT|DBF_ENUM|DBF_CHAR|DBF_LONG|DBF_DOUBLE|DBF_MENU)\\b"
+					"match": "\\b(DBF_STRING|DBF_U?CHAR|DBF_U?SHORT|DBF_U?LONG|DBF_U?INT64|DBF_FLOAT|DBF_DOUBLE|DBF_ENUM|DBF_MENU|DBF_DEVICE|DBF_(IN|OUT|FWD)LINK|DBF_NOACCESS)\\b",
+					"comment": "Source: include/dbFldTypes.h"
+				},
+				{
+					"name": "constant.language.pp.epics",
+					"match": "\\b(YES|NO|TRUE|FALSE)\\b",
+					"comment": "Source: dbRecordtypeFieldItem(), ioc/dbStatic/dbLexRoutines.c"
+				},
+				{
+					"name": "constant.language.asl.epics",
+					"match": "\\b(ASL0|ASL1)\\b",
+					"comment": "Source: dbRecordtypeFieldItem(), ioc/dbStatic/dbLexRoutines.c"
+				},
+				{
+					"name": "constant.language.base.epics",
+					"match": "\\b(DECIMAL|HEX)\\b",
+					"comment": "Source: dbRecordtypeFieldItem(), ioc/dbStatic/dbLexRoutines.c"
+				},
+				{
+					"name": "constant.language.special.epics",
+					"match": "\\b(SPC_NOMOD|SPC_DBADDR|SPC_SCAN|SPC_ALARMACK|SPC_AS|SPC_MOD|SPC_RESET|SPC_LINCONV|SPC_CALC)\\b",
+					"comment": "Source: include/special.h"
 				}
 			]
 		},
@@ -38,12 +60,13 @@
 			"begin": "\"",
 			"end": "\"",
 			"patterns": [
-				{
-					"name": "constant.character.escape.epics",
-					"match": "\\\\.",
-					"include": "#macros"
-				}
+				{ "include": "#macros" },
+				{ "include": "#escaped_char" }
 			]
+		},
+		"escaped_char": {
+			"name": "constant.character.escape.epics",
+			"match": "\\\\."
 		},
 		"macros": {
 			"patterns": [
@@ -58,10 +81,7 @@
 			"begin": "#",
 			"end": "^",
 			"patterns": [
-				{
-					"name":"constant.character.escape.epics",
-					"match": "\\\\."
-				}
+				{ "include": "#escaped_char" }
 			]
 		}
 	}

--- a/syntaxes/dbd.tmLanguage.json
+++ b/syntaxes/dbd.tmLanguage.json
@@ -25,7 +25,7 @@
 				},
 				{
 					"name": "keyword.control.field.epics",
-					"match": "\\b(prompt|prompt[gG]roup|asl|interest|size|extra|special|menu)\\b"
+					"match": "\\b(prompt|prompt[gG]roup|asl|interest|size|extra|special|menu|pp)\\b"
 				},
 				{
 					"name": "constant.language.dbf.epics",

--- a/test/test.dbd
+++ b/test/test.dbd
@@ -35,5 +35,6 @@ recordtype(xxxRecordType) {
         size(4)
         extra("void *         cbst")
         menu(xxxRecordXXX)
+        pp(TRUE)
     }
 }

--- a/test/test.dbd
+++ b/test/test.dbd
@@ -24,17 +24,20 @@ menu(xxxRecordXXX) {
     choice(xxxRecordXXX_Choice_3,"Choice 3")
 }
 
-# Record type with a field
+# Record type with a \"field\"
 recordtype(xxxRecordType) {
-    field(XXX,DBF_FLOAT) {
-        prompt("Pointer to custom structure")
-        promptgroup(GUI_BITS1)
-        special(SPC_NOMOD)
+    field(XXX,DBF_DOUBLE) {
         asl(ASL0)
+        initial("123.456")
+        promptgroup(GUI_BITS1)
+        prompt("Pointer to \"custom\" structure")
+        special(SPC_NOMOD)
+        pp(TRUE)
         interest(1)
+        base(DECIMAL)
         size(4)
         extra("void *         cbst")
         menu(xxxRecordXXX)
-        pp(TRUE)
+        prop(YES)
     }
 }

--- a/test/test.dbd
+++ b/test/test.dbd
@@ -17,3 +17,23 @@ function(integrateWF)
 # Variables
 variable(<variable name>)
 
+# Menu
+menu(xxxRecordXXX) {
+    choice(xxxRecordXXX_Choice_1,"Choice 1")
+    choice(xxxRecordXXX_Choice_2,"Choice 2")
+    choice(xxxRecordXXX_Choice_3,"Choice 3")
+}
+
+# Record type with a field
+recordtype(xxxRecordType) {
+    field(XXX,DBF_FLOAT) {
+        prompt("Pointer to custom structure")
+        promptgroup(GUI_BITS1)
+        special(SPC_NOMOD)
+        asl(ASL0)
+        interest(1)
+        size(4)
+        extra("void *         cbst")
+        menu(xxxRecordXXX)
+    }
+}


### PR DESCRIPTION
Solves #28 

**Purpose**
EPICS base DBDs do not highlight all keywords.

**Solution**
* Added field-related keywords (e.g. pp) in the DBD file.
* Added enums with field-related keywords in a DBD file.
* Corrected highlighting of escaped characters in a string.
* Extended test.dbd file with examples.
